### PR TITLE
issue #4 : add "-j" option  to make command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,5 +12,5 @@ RUN apk add --no-cache \
         mesa-dev \
     && cd /mve \
     && mkdir bin \
-    && make all
+    && make -j"$(nproc)" all
 


### PR DESCRIPTION
## Issue to solve
* #4

## What I did

* add -j"$(nproc)" option to make command

##  What I confirmed

In my environment. build time was reduced from 247.6 seconds to 126.6 seconds.

* before change
```
$ time docker build .
[+] Building 247.6s (8/8) FINISHED                                                                                              
 => [internal] load .dockerignore                                                                                          0.2s
 => => transferring context: 44B                                                                                           0.0s
 => [internal] load build definition from Dockerfile                                                                       0.1s
 => => transferring dockerfile: 292B                                                                                       0.0s
 => [internal] load metadata for docker.io/library/alpine:3.12                                                             1.8s
 => [internal] load build context                                                                                          0.1s
 => => transferring context: 69.92kB                                                                                       0.0s
 => CACHED [1/3] FROM docker.io/library/alpine:3.12@sha256:c75ac27b49326926b803b9ed43bf088bc220d22556de1bc5f72d742c91398f  0.0s
 => [2/3] COPY . /mve                                                                                                      1.1s
 => [3/3] RUN apk add --no-cache         make         g++         jpeg-dev         libpng-dev         tiff-dev           240.1s
 => exporting to image                                                                                                     4.1s
 => => exporting layers                                                                                                    4.1s
 => => writing image sha256:60cfff02ab04f49e27cd68dba83389034998e0c495d0c3836d2e6fb6c56492d7                               0.0s 
                                                                                                                                
real    4m7.780s                                                                                                                
user    0m0.536s                                                                                                                
sys	0m0.201s
$
```
* after change
```
 time docker build .
[+] Building 126.6s (8/8) FINISHED                                                                                              
 => [internal] load .dockerignore                                                                                          0.1s
 => => transferring context: 44B                                                                                           0.0s
 => [internal] load build definition from Dockerfile                                                                       0.1s
 => => transferring dockerfile: 305B                                                                                       0.0s
 => [internal] load metadata for docker.io/library/alpine:3.12                                                             1.7s
 => [internal] load build context                                                                                          0.1s
 => => transferring context: 68.13kB                                                                                       0.0s
 => CACHED [1/3] FROM docker.io/library/alpine:3.12@sha256:c75ac27b49326926b803b9ed43bf088bc220d22556de1bc5f72d742c91398f  0.0s
 => [2/3] COPY . /mve                                                                                                      1.1s
 => [3/3] RUN apk add --no-cache         make         g++         jpeg-dev         libpng-dev         tiff-dev           118.4s
 => exporting to image                                                                                                     5.1s
 => => exporting layers                                                                                                    5.1s
 => => writing image sha256:18b25251c9ecb2fd8f415dab64a919941f386698a6b1b0bdd383f6284059ab5f                               0.0s 
                                                                                                                                
real    2m6.797s                                                                                                                
user    0m0.351s                                                                                                                
sys	0m0.159s
$
```
