### PR TITLE
link generated files to the "mve/bin" directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,10 @@ ARG ALPINE_VERSION=3.12
 FROM alpine:${ALPINE_VERSION}
 
 COPY . /mve
+WORKDIR /mve
+
+ENV HOME=/mve
+ENV PATH=$PATH:$HOME/bin
 
 RUN apk add --no-cache \
         make \
@@ -10,7 +14,7 @@ RUN apk add --no-cache \
         libpng-dev \
         tiff-dev \
         mesa-dev \
-    && cd /mve \
     && mkdir bin \
-    && make -j"$(nproc)" all
+    && make -j"$(nproc)" all \
+    && make container_links
 

--- a/Makefile
+++ b/Makefile
@@ -21,4 +21,8 @@ clean:
 links:
 	$(MAKE) -C apps $@
 
+# Creates symbolic links to all apps in $HOME/bin/ of container
+container_links:
+	$(MAKE) -C apps $@
+
 .PHONY: all doc test clean links

--- a/apps/Makefile
+++ b/apps/Makefile
@@ -47,4 +47,20 @@ links:
 	ln -si $(APPDIR)/prebundle/prebundle $(BINDIR)
 	ln -si $(APPDIR)/umve/umve $(BINDIR)
 
-.PHONY: all clean links
+container_links:
+	ln -s $(APPDIR)/bundle2pset/bundle2pset $(BINDIR)
+	ln -s $(APPDIR)/dmrecon/dmrecon $(BINDIR)
+	ln -s $(APPDIR)/makescene/makescene $(BINDIR)
+	ln -s $(APPDIR)/meshconvert/meshconvert $(BINDIR)
+	ln -s $(APPDIR)/scene2pset/scene2pset $(BINDIR)
+	ln -s $(APPDIR)/sfmrecon/sfmrecon $(BINDIR)
+	ln -s $(APPDIR)/featurerecon/featurerecon $(BINDIR)
+	ln -s $(APPDIR)/fssrecon/fssrecon $(BINDIR)
+	ln -s $(APPDIR)/mesh2pset/mesh2pset $(BINDIR)
+	ln -s $(APPDIR)/meshalign/meshalign $(BINDIR)
+	ln -s $(APPDIR)/meshclean/meshclean $(BINDIR)
+	ln -s $(APPDIR)/sceneupgrade/sceneupgrade $(BINDIR)
+	ln -s $(APPDIR)/prebundle/prebundle $(BINDIR)
+	ln -s $(APPDIR)/umve/umve $(BINDIR)
+
+.PHONY: all clean links container_links


### PR DESCRIPTION
## Issue to solve
* #5

## What I did

* I added the ablity to install executables in "mve/bin" directory of container with the "make container_links" command. Bcause the ln command "-i" option is not available on the Alpine Linux.

##  What I confirmed

I verified that the generated commands can be executed at the mve directory in the container.
```
/mve # fssrecon
Floating Scale Surface Reconstruction (built on May  1 2023, 07:33:23)

Samples the implicit function defined by the input samples and produces a
surface mesh. The input samples must have normals and the "values" PLY
attribute (the scale of the samples). Both confidence values and vertex
colors are optional. The final surface should be cleaned (sliver triangles,
isolated components, low-confidence vertices) afterwards.

Usage: fssrecon [ OPTS ] IN_PLY [ IN_PLY ... ] OUT_PLY
Available options: 
  -s, --scale-factor=ARG   Multiply sample scale with factor [1.0]
  -r, --refine-octree=ARG  Refines octree with N levels [0]
  --min-scale=ARG          Minimum scale, smaller samples are clamped
  --max-scale=ARG          Maximum scale, larger samples are ignored
  --interpolation=ARG      Interpolation: linear, scaling, lsderiv, [cubic]

Error: Too few non-option arguments
/mve # 
```