### PR TITLE
set timzone in the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,24 @@
 ARG ALPINE_VERSION=3.12
 FROM alpine:${ALPINE_VERSION}
 
-COPY . /mve
-WORKDIR /mve
-
-ENV HOME=/mve
-ENV PATH=$PATH:$HOME/bin
-
-RUN apk add --no-cache \
+ARG TIMEZONE=Asia/Tokyo
+RUN apk add --no-cache tzdata \
         make \
         g++ \
         jpeg-dev \
         libpng-dev \
         tiff-dev \
-        mesa-dev \
-    && mkdir bin \
+        mesa-dev && \
+    cp  /usr/share/zoneinfo/${TIMEZONE} /etc/localtime && \
+    apk del tzdata && \
+    rm -rf /var/cache/apk/*
+
+COPY . /mve
+WORKDIR /mve
+ENV HOME=/mve
+
+RUN mkdir bin \
     && make -j"$(nproc)" all \
     && make container_links
 
+ENV PATH=$PATH:$HOME/bin

--- a/compose.yml
+++ b/compose.yml
@@ -2,6 +2,11 @@ services:
   mve:
     build:
       context: .
+      # Timezoe and Alpine Linux version can be specified by enabling the following args: parameters.
+      # The following values are defaulted in the Dockerfile.
+      # args:
+      #   - ALPINE_VERSION=3.12
+      #   - TIMEZOME=Asia/Tokyo
     tty: true
     volumes:
       - ./data:/mve/data


### PR DESCRIPTION
## Issue to solve
* #2
* And Alpine Linux version can be specified

## What I did
* Timezone of the container is set. 
  * Set default timezone is Asia/Tokyo in the Dockerfile.
  * Timezone can be specified in the compose.yml file.
* Other ( additional )
  * Set default Alpine Linux version is 3.12 in the Dockerfile.
  * Alpine Linux version can be specified in the compose.yml file.
  * Attension : Segmentation fault error occurs in Alpine Linux version 3.13 or later.

##  What I confirmed
* docker build and docker compose build should work propely
```
$ docker build -t testmve .
[+] Building 118.7s (10/10) FINISHED                                                                                            
 => [internal] load .dockerignore                                                                                          0.4s
 => => transferring context: 44B                                                                                           0.0s
 => [internal] load build definition from Dockerfile                                                                       0.3s
 => => transferring dockerfile: 514B                                                                                       0.0s
 => [internal] load metadata for docker.io/library/alpine:3.12                                                             1.6s
 => [1/5] FROM docker.io/library/alpine:3.12@sha256:c75ac27b49326926b803b9ed43bf088bc220d22556de1bc5f72d742c91398f69       0.0s
 => [internal] load build context                                                                                          0.2s
 => => transferring context: 7.55MB                                                                                        0.1s
 => CACHED [2/5] RUN apk add --no-cache tzdata         make         g++         jpeg-dev         libpng-dev         tiff-  0.0s
 => [3/5] COPY . /mve                                                                                                      1.3s
 => [4/5] WORKDIR /mve                                                                                                     0.8s
 => [5/5] RUN mkdir bin     && make -j"$(nproc)" all     && make container_links                                         112.7s
 => exporting to image                                                                                                     1.7s
 => => exporting layers                                                                                                    1.6s
 => => writing image sha256:9e6bd156350b3d2a649a5deb8b522e35483c92ca1caac3fbf4909739dec13a95                               0.0s 
 => => naming to docker.io/library/testmve 

$ docker compose up -d --build
[+] Building 1.2s (10/10) FINISHED                                                                                              
 => [internal] load build definition from Dockerfile                                                                       0.1s
 => => transferring dockerfile: 514B                                                                                       0.0s
 => [internal] load .dockerignore                                                                                          0.1s
 => => transferring context: 44B                                                                                           0.0s
 => [internal] load metadata for docker.io/library/alpine:3.12                                                             0.8s
 => [internal] load build context                                                                                          0.2s
 => => transferring context: 29.29kB                                                                                       0.0s
 => [1/5] FROM docker.io/library/alpine:3.12@sha256:c75ac27b49326926b803b9ed43bf088bc220d22556de1bc5f72d742c91398f69       0.0s
 => CACHED [2/5] RUN apk add --no-cache tzdata         make         g++         jpeg-dev         libpng-dev         tiff-  0.0s
 => CACHED [3/5] COPY . /mve                                                                                               0.0s
 => CACHED [4/5] WORKDIR /mve                                                                                              0.0s
 => CACHED [5/5] RUN mkdir bin     && make -j"$(nproc)" all     && make container_links                                    0.0s
 => exporting to image                                                                                                     0.1s
 => => exporting layers                                                                                                    0.0s
 => => writing image sha256:3b0f046a004b3e60be80c8a687c7ba7f8f0e40d3e9a0af70ec6a98d459b1ad3f                               0.1s
 => => naming to docker.io/library/mve-mve                                                                                 0.1s
[+] Running 1/1
 ✔ Container mve-mve-1  Started
```
* Confirmed that the timezone is working as specified.
```
$ docker compose exec mve date
Tue May  2 01:34:15 JST 2023
```
* Ensured the build time is in specified timezone.
```
$ docker compose exec mve ./reconst_pipe.sh
MVE Makescene (built on May  2 2023, 01:30:50)

** Warning: Output dir already exists.
** This may leave old views in your scene.
-> Press ENTER to continue, or CTRL-C to exit.
Found 1 directory entries.
Creating output directories...
Skipping file .gitkeep, cannot load image.
Imported 0 input images, took 3 ms.
MVE SfM Reconstruction (built on May  2 2023, 01:31:04)
SSE2 accelerated matching is enabled.
SSE3 accelerated matching is enabled.
Initializing scene with 0 views...
Initialized 0 views (max ID is 0), took 0ms.
Computing image features...
Arithmetic exception (core dumped)
MVE Depth Map Reconstruction (built on May  2 2023, 01:30:46)
Initializing scene with 0 views...
Initialized 0 views (max ID is 0), took 0ms.
Error loading scene: No such file or directory
MVE Scene to Pointset (built on May  2 2023, 01:30:59)
Using depthmap "depth-L2" and color image "undist-L2"
Initializing scene with 0 views...
Initialized 0 views (max ID is 0), took 0ms.
Writing final point set (0 points)...
Writing PLY file (0 verts, with colors, with normals, with confidences, with values, 0 faces)... done.
Floating Scale Surface Reconstruction (built on May  2 2023, 01:31:12)
Loading: data/scene/pset-L2.ply...
Loading samples took 0ms.
Octree does not contain any samples, exiting.
MVE FSSR Mesh Cleaning (built on May  2 2023, 01:31:20)
Loading mesh: data/scene/surface-L2.ply
Error loading mesh: No such file or directory
```
