### PR TITLE
Issue#3 mve user executes commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ FROM alpine:${ALPINE_VERSION}
 
 ARG TIMEZONE=Asia/Tokyo
 RUN apk add --no-cache tzdata \
-        doas \
         make \
         g++ \
         jpeg-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM alpine:${ALPINE_VERSION}
 
 ARG TIMEZONE=Asia/Tokyo
 RUN apk add --no-cache tzdata \
+        doas \
         make \
         g++ \
         jpeg-dev \
@@ -11,14 +12,17 @@ RUN apk add --no-cache tzdata \
         mesa-dev && \
     cp  /usr/share/zoneinfo/${TIMEZONE} /etc/localtime && \
     apk del tzdata && \
-    rm -rf /var/cache/apk/*
+    rm -rf /var/cache/apk/* && \
+    addgroup -S mve && \    
+    adduser -S mve -D -G mve -h /mve
 
 COPY . /mve
 WORKDIR /mve
-ENV HOME=/mve
 
-RUN mkdir bin \
-    && make -j"$(nproc)" all \
-    && make container_links
+RUN mkdir bin && \
+    make -j"$(nproc)" all && \
+    make container_links && \
+    chown -R mve:mve /mve
 
-ENV PATH=$PATH:$HOME/bin
+USER mve
+

--- a/apps/Makefile
+++ b/apps/Makefile
@@ -30,6 +30,7 @@ clean:
 
 BINDIR ?= $(HOME)/bin/
 APPDIR := $(shell pwd)
+UL_BINDIR = /usr/local/bin/
 
 links:
 	ln -si $(APPDIR)/bundle2pset/bundle2pset $(BINDIR)
@@ -48,19 +49,19 @@ links:
 	ln -si $(APPDIR)/umve/umve $(BINDIR)
 
 container_links:
-	ln -s $(APPDIR)/bundle2pset/bundle2pset $(BINDIR)
-	ln -s $(APPDIR)/dmrecon/dmrecon $(BINDIR)
-	ln -s $(APPDIR)/makescene/makescene $(BINDIR)
-	ln -s $(APPDIR)/meshconvert/meshconvert $(BINDIR)
-	ln -s $(APPDIR)/scene2pset/scene2pset $(BINDIR)
-	ln -s $(APPDIR)/sfmrecon/sfmrecon $(BINDIR)
-	ln -s $(APPDIR)/featurerecon/featurerecon $(BINDIR)
-	ln -s $(APPDIR)/fssrecon/fssrecon $(BINDIR)
-	ln -s $(APPDIR)/mesh2pset/mesh2pset $(BINDIR)
-	ln -s $(APPDIR)/meshalign/meshalign $(BINDIR)
-	ln -s $(APPDIR)/meshclean/meshclean $(BINDIR)
-	ln -s $(APPDIR)/sceneupgrade/sceneupgrade $(BINDIR)
-	ln -s $(APPDIR)/prebundle/prebundle $(BINDIR)
-	ln -s $(APPDIR)/umve/umve $(BINDIR)
+	ln -s $(APPDIR)/bundle2pset/bundle2pset $(UL_BINDIR)
+	ln -s $(APPDIR)/dmrecon/dmrecon $(UL_BINDIR)
+	ln -s $(APPDIR)/makescene/makescene $(UL_BINDIR)
+	ln -s $(APPDIR)/meshconvert/meshconvert $(UL_BINDIR)
+	ln -s $(APPDIR)/scene2pset/scene2pset $(UL_BINDIR)
+	ln -s $(APPDIR)/sfmrecon/sfmrecon $(UL_BINDIR)
+	ln -s $(APPDIR)/featurerecon/featurerecon $(UL_BINDIR)
+	ln -s $(APPDIR)/fssrecon/fssrecon $(UL_BINDIR)
+	ln -s $(APPDIR)/mesh2pset/mesh2pset $(UL_BINDIR)
+	ln -s $(APPDIR)/meshalign/meshalign $(UL_BINDIR)
+	ln -s $(APPDIR)/meshclean/meshclean $(UL_BINDIR)
+	ln -s $(APPDIR)/sceneupgrade/sceneupgrade $(UL_BINDIR)
+	ln -s $(APPDIR)/prebundle/prebundle $(UL_BINDIR)
+	#ln -s $(APPDIR)/umve/umve $(UL_BINDIR)
 
 .PHONY: all clean links container_links


### PR DESCRIPTION
## Issue to solve
* #3

## What I did
* Add user "mve" and group "mve"
* Create symbolic links to /usr/local/bin for files under the generated apps directory
* Container excution user is switched to "mve" user

##  What I confirmed
* docker build and docker compose build should work propely
```
$ docker build -t testmve2 . 
[+] Building 143.3s (10/10) FINISHED                                                            
 => [internal] load .dockerignore                                                          0.1s
 => => transferring context: 129B                                                          0.0s
 => [internal] load build definition from Dockerfile                                       0.2s
 => => transferring dockerfile: 587B                                                       0.0s
 => [internal] load metadata for docker.io/library/alpine:3.12                             0.9s
 => [internal] load build context                                                          0.1s
 => => transferring context: 21.91kB                                                       0.0s
 => CACHED [1/5] FROM docker.io/library/alpine:3.12@sha256:c75ac27b49326926b803b9ed43bf08  0.0s
 => [2/5] RUN apk add --no-cache tzdata         make         g++         jpeg-dev          9.6s
 => [3/5] COPY . /mve                                                                      1.2s
 => [4/5] WORKDIR /mve                                                                     1.0s 
 => [5/5] RUN mkdir bin &&     make -j"$(nproc)" all &&     make container_links &&      126.6s 
 => exporting to image                                                                     3.4s 
 => => exporting layers                                                                    3.4s 
 => => writing image sha256:909400a7ea62d88d59b7236594362e5ad7787c5ebaad4debb8f84b776d869  0.0s 
 => => naming to docker.io/library/testmve2                                                0.0s 

$ docker compose up -d --build
[+] Building 2.2s (10/10) FINISHED                                                              
 => [internal] load .dockerignore                                                          0.1s
 => => transferring context: 129B                                                          0.0s
 => [internal] load build definition from Dockerfile                                       0.3s
 => => transferring dockerfile: 587B                                                       0.0s
 => [internal] load metadata for docker.io/library/alpine:3.12                             1.7s
 => [1/5] FROM docker.io/library/alpine:3.12@sha256:c75ac27b49326926b803b9ed43bf088bc220d  0.0s
 => [internal] loaktnk@aktnk-All-Series:~/projects/mvead build context                                                          0.1s
 => => transferring context: 21.91kB                                                       0.0s
 => CACHED [2/5] RUN apk add --no-cache tzdata         make         g++         jpeg-dev   0.0s
 => CACHED [3/5] COPY . /mve                                                               0.0s
 => CACHED [4/5] WORKDIR /mve                                                              0.0s
 => CACHED [5/5] RUN mkdir bin &&     make -j"$(nproc)" all &&     make container_links &  0.0s
 => exporting to image                                                                     0.1s
 => => exporting layers                                                                    0.0s
 => => writing image sha256:81db370c5131708c514294a05ee907b0e6f464ae3b7648b33ceeab39ba6dd  0.0s
 => => naming to docker.io/library/mve-mve                                                 0.0s
[+] Running 1/1
 ✔ Container mve-mve-1  Started                                                           13.7s 
$ 

```
* Verified that the genearted commands can be executed
```
$ docker run testmve2 fssrecon                             
Floating Scale Surface Reconstruction (built on May  3 2023, 12:03:08)                          

Samples the implicit function defined by the input samples and produces a
surface mesh. The input samples must have normals and the "values" PLY
attribute (the scale of the samples). Both confidence values and vertex
colors are optional. The final surface should be cleaned (sliver triangles,
isolated components, low-confidence vertices) afterwards.

Usage: fssrecon [ OPTS ] IN_PLY [ IN_PLY ... ] OUT_PLY
Available options: 
  -s, --scale-factor=ARG   Multiply sample scale with factor [1.0]
  -r, --refine-octree=ARG  Refines octree with N levels [0]
  --min-scale=ARG          Minimum scale, smaller samples are clamped
  --max-scale=ARG          Maximum scale, larger samples are ignored
  --interpolation=ARG      Interpolation: linear, scaling, lsderiv, [cubic]

Error: Too few non-option arguments

$ docker compose exec mve fssrecon
Floating Scale Surface Reconstruction (built on May  3 2023, 12:03:08)

Samples the implicit function defined by the input samples and produces a
surface mesh. The input samples must have normals and the "values" PLY
attribute (the scale of the samples). Both confidence values and vertex
colors are optional. The final surface should be cleaned (sliver triangles,
isolated components, low-confidence vertices) afterwards.

Usage: fssrecon [ OPTS ] IN_PLY [ IN_PLY ... ] OUT_PLY
Available options: 
  -s, --scale-factor=ARG   Multiply sample scale with factor [1.0]
  -r, --refine-octree=ARG  Refines octree with N levels [0]
  --min-scale=ARG          Minimum scale, smaller samples are clamped
  --max-scale=ARG          Maximum scale, larger samples are ignored
  --interpolation=ARG      Interpolation: linear, scaling, lsderiv, [cubic]

Error: Too few non-option arguments
```
* Verified that the container execution use is the "mve" user
```
$ docker compose exec mve /bin/sh
~ $ whoami
mve
~ $ groups
mve
~ $ exit
```