### PR TITLE
update .dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,9 @@
+# data directory
 data
+
+# git local repository
+.git
+
+# docker files
+compose.yml
+Dockerfile


### PR DESCRIPTION
## Issue to solve
* #13

## What I did
* update .dockerignore

##  What I confirmed
* docker build should work propely and verified that the image size has been reduced
  * before 
```
$ docker build -t testmve3 . 
[+] Building 130.3s (10/10) FINISHED                                                            
 => [internal] load build definition from Dockerfile                                       0.1s
 => => transferring dockerfile: 587B                                                       0.0s
 => [internal] load .dockerignore                                                          0.1s
 => => transferring context: 62B                                                           0.0s
 => [internal] load metadata for docker.io/library/alpine:3.12                             2.1s
 => [1/5] FROM docker.io/library/alpine:3.12@sha256:c75ac27b49326926b803b9ed43bf088bc220d  0.0s
 => [internal] load build context                                                          0.3s
 => => transferring context: 4.34MB                                                        0.2s
 => CACHED [2/5] RUN apk add --no-cache tzdata         make         g++         jpeg-dev   0.0s
 => [3/5] COPY . /mve                                                                      1.4s
 => [4/5] WORKDIR /mve                                                                     1.0s
 => [5/5] RUN mkdir bin &&     make -j"$(nproc)" all &&     make container_links &&      123.4s
 => exporting to image                                                                     2.0s
 => => exporting layers                                                                    1.9s
 => => writing image sha256:d29180ae49a56c854326fafecd7a4cdf09b2e0d63d74b1140d2a315ed8014  0.0s 
 => => naming to docker.io/library/testmve3                                                0.0s 

$ docker images
REPOSITORY                        TAG       IMAGE ID       CREATED              SIZE            
testmve3                          latest    d29180ae49a5   About a minute ago   689MB
```
  * after
```
$ docker build -t testmve4 . 
[+] Building 2.0s (10/10) FINISHED                                                              
 => [internal] load .dockerignore                                                          0.1s
 => => transferring context: 129B                                                          0.0s
 => [internal] load build definition from Dockerfile                                       0.1s
 => => transferring dockerfile: 587B                                                       0.0s
 => [internal] load metadata for docker.io/library/alpine:3.12                             1.6s
 => [1/5] FROM docker.io/library/alpine:3.12@sha256:c75ac27b49326926b803b9ed43bf088bc220d  0.0s
 => [internal] load build context                                                          0.1s
 => => transferring context: 22.01kB                                                       0.0s
 => CACHED [2/5] RUN apk add --no-cache tzdata         make         g++         jpeg-dev   0.0s
 => CACHED [3/5] COPY . /mve                                                               0.0s
 => CACHED [4/5] WORKDIR /mve                                                              0.0s
 => CACHED [5/5] RUN mkdir bin &&     make -j"$(nproc)" all &&     make container_links &  0.0s
 => exporting to image                                                                     0.1s
 => => exporting layers                                                                    0.0s
 => => writing image sha256:909400a7ea62d88d59b7236594362e5ad7787c5ebaad4debb8f84b776d869  0.0s
 => => naming to docker.io/library/testmve4                                                0.0s

$ docker images
REPOSITORY                        TAG       IMAGE ID       CREATED             SIZE
testmve4                          latest    909400a7ea62   21 minutes ago      680MB
```